### PR TITLE
Multiple coda connection support and axios upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/google-mac/coda-js",
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.19.2"
   },
   "devDependencies": {
     "microbundle": "^0.11.0"

--- a/src/API.ts
+++ b/src/API.ts
@@ -1,17 +1,20 @@
 import axios, { AxiosRequestConfig, Method } from 'axios';
 
 class API {
+  private _axiosInstance: any;
+
   constructor(token: string) {
-    // set up axios defaults
-    axios.defaults.baseURL = 'https://coda.io/apis/v1beta1';
-    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    this._axiosInstance = axios.create({
+      baseURL: 'https://coda.io/apis/v1beta1',
+      headers: {'Authorization': `Bearer ${token}`}
+    });
   }
 
   async request(url: string, params: any = {}, method: Method = 'GET'): Promise<any> {
     try {
       const options: AxiosRequestConfig = ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase()) ? { url, method, data: params } : { url, method, params };
 
-      return await axios(options);
+      return await this._axiosInstance(options);
     } catch (error) {
       console.error(error);
     }
@@ -20,7 +23,7 @@ class API {
   async deleteWithBody(url: string, params: any = {}): Promise<any> {
     try {
       const options: AxiosRequestConfig = { url, method: 'DELETE', data: params };
-      return await axios(options);
+      return await this._axiosInstance(options);
     } catch (error) {
       console.error(error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,13 +320,12 @@ autoprefixer@^9.0.0:
     postcss "^7.0.23"
     postcss-value-parser "^4.0.2"
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 babel-plugin-transform-async-to-promises@^0.8.3:
   version "0.8.15"
@@ -1374,11 +1373,6 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-is-buffer@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
-  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
As discussed in a [proposal](https://github.com/parker-codes/coda-js/issues/7):
1. Proposing multiple Coda connection support.
2. Upgrading Axios to the current latest [0.19.2](https://github.com/axios/axios/blob/master/CHANGELOG.md).