### PR TITLE
V1 migration Issues 1 to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ For example:
 
 ```js
 // uses two requests, but makes sense when you don't know all information ahead of time
-const doc = await coda.getDoc("O7d9JvX0GY");
-const table = await doc.getTable("grid-_14oaR8gdM");
+const doc = await coda.getDoc('O7d9JvX0GY');
+const table = await doc.getTable('grid-_14oaR8gdM');
 ```
 
 could be consolidated into:
 
 ```js
 // uses only one request, which is best when you already know the exact IDs to get the item(s) directly
-await coda.getTable("O7d9JvX0GY", "grid-_14oaR8gdM");
+await coda.getTable('O7d9JvX0GY', 'grid-_14oaR8gdM');
 ```
 
 ## Notice
@@ -68,9 +68,9 @@ Please note that the examples are currently only displaying async/await usage. Y
 #### Testing Connection
 
 ```js
-import { Coda } from "coda-js";
+import { Coda } from 'coda-js';
 
-const coda = new Coda("**********-********-*********"); // insert your token
+const coda = new Coda('**********-********-*********'); // insert your token
 
 // trick for using async in a script
 (async () => {
@@ -117,8 +117,8 @@ Inserting also has a second parameter of keyColumns that allows for an "upsert".
 // inserting using object
 await table.insertRows([
   {
-    Name: "Jacob",
-    Action: "Take out the trash",
+    Name: 'Jacob',
+    Action: 'Take out the trash',
     Completed: true,
   },
 ]);
@@ -126,13 +126,13 @@ await table.insertRows([
 // inserting via column objects
 await table.insertRows([
   [
-    { column: "Name", value: "Alexis" },
-    { column: "Action", value: "Do the dishes" },
+    { column: 'Name', value: 'Alexis' },
+    { column: 'Action', value: 'Do the dishes' },
   ],
   [
-    { column: "Name", value: "Parker" },
-    { column: "Action", value: "Make dinner" },
-    { column: "Completed", value: true },
+    { column: 'Name', value: 'Parker' },
+    { column: 'Action', value: 'Make dinner' },
+    { column: 'Completed', value: true },
   ],
 ]);
 ```
@@ -141,18 +141,18 @@ await table.insertRows([
 
 ```js
 // updating (using column name instead of ID)
-await table.updateRow("i-cpDDo9hAEU", {
+await table.updateRow('i-cpDDo9hAEU', {
   Completed: false,
 });
 
 // updating via column objects
-await table.updateRow("i-dF2-OoiiUi", [
-  { column: "Action", value: "Make the bed" },
+await table.updateRow('i-dF2-OoiiUi', [
+  { column: 'Action', value: 'Make the bed' },
 ]);
 
 // updating off of an already fetched row
 await row2.update({
-  "ai-dRD9afcc8": "To the moon, Alice!",
+  'ai-dRD9afcc8': 'To the moon, Alice!',
 });
 ```
 
@@ -160,14 +160,14 @@ await row2.update({
 
 ```js
 // delete row directly
-const row4 = await table.getRow("i-Ef2-OoZxIi");
+const row4 = await table.getRow('i-Ef2-OoZxIi');
 await row4.delete();
 
 // delete row from table
-await table.deleteRow("i-cpDDoshUEU");
+await table.deleteRow('i-cpDDoshUEU');
 
 // deleting multiple rows from table
-await table.deleteRows(["i-cpDDoshUEU", "i-jj81vtosO1"]);
+await table.deleteRows(['i-cpDDoshUEU', 'i-jj81vtosO1']);
 ```
 
 #### Error Handling
@@ -182,7 +182,7 @@ Error types:
 - TooManyRequestsError (429)
 
 ```js
-import { Coda, UnauthorizedError, NotFoundError } from "../index";
+import { Coda, UnauthorizedError, NotFoundError } from '../index';
 const coda = new Coda(process.env.TOKEN);
 
 // doesn't have access to view docs
@@ -195,7 +195,7 @@ try {
 
 // fails to find a doc with a bad ID
 try {
-  const BAD_DOC_ID = "d-ckjd1013kkk";
+  const BAD_DOC_ID = 'd-ckjd1013kkk';
   await coda.listTables(BAD_DOC_ID);
 } catch (error) {
   // error is instance of NotFoundError

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ For example:
 
 ```js
 // uses two requests, but makes sense when you don't know all information ahead of time
-const doc = await coda.getDoc('O7d9JvX0GY');
-const table = await doc.getTable('grid-_14oaR8gdM');
+const doc = await coda.getDoc("O7d9JvX0GY");
+const table = await doc.getTable("grid-_14oaR8gdM");
 ```
 
 could be consolidated into:
 
 ```js
 // uses only one request, which is best when you already know the exact IDs to get the item(s) directly
-await coda.getTable('O7d9JvX0GY', 'grid-_14oaR8gdM');
+await coda.getTable("O7d9JvX0GY", "grid-_14oaR8gdM");
 ```
 
 ## Notice
@@ -68,9 +68,9 @@ Please note that the examples are currently only displaying async/await usage. Y
 #### Testing Connection
 
 ```js
-import { Coda } from 'coda-js';
+import { Coda } from "coda-js";
 
-const coda = new Coda('**********-********-*********'); // insert your token
+const coda = new Coda("**********-********-*********"); // insert your token
 
 // trick for using async in a script
 (async () => {
@@ -100,6 +100,10 @@ const firstRow = rows[0];
 console.log(firstRow.values); // column/value pairs
 console.log(firstRow.listValues()); // each column is object with column and value properties
 
+const tabeType =table.tableType; //get tableType
+const parentTable = tableType==="view" ? return table.parentTable : table; // if the table is a view, we can access its parent Table.
+console.log(parentTable.id)
+
 const controls = await coda.listControls('some-doc-ID');
 // or
 const controls = await firstDoc.listControls();
@@ -113,8 +117,8 @@ Inserting also has a second parameter of keyColumns that allows for an "upsert".
 // inserting using object
 await table.insertRows([
   {
-    Name: 'Jacob',
-    Action: 'Take out the trash',
+    Name: "Jacob",
+    Action: "Take out the trash",
     Completed: true,
   },
 ]);
@@ -122,13 +126,13 @@ await table.insertRows([
 // inserting via column objects
 await table.insertRows([
   [
-    { column: 'Name', value: 'Alexis' },
-    { column: 'Action', value: 'Do the dishes' },
+    { column: "Name", value: "Alexis" },
+    { column: "Action", value: "Do the dishes" },
   ],
   [
-    { column: 'Name', value: 'Parker' },
-    { column: 'Action', value: 'Make dinner' },
-    { column: 'Completed', value: true },
+    { column: "Name", value: "Parker" },
+    { column: "Action", value: "Make dinner" },
+    { column: "Completed", value: true },
   ],
 ]);
 ```
@@ -137,16 +141,18 @@ await table.insertRows([
 
 ```js
 // updating (using column name instead of ID)
-await table.updateRow('i-cpDDo9hAEU', {
+await table.updateRow("i-cpDDo9hAEU", {
   Completed: false,
 });
 
 // updating via column objects
-await table.updateRow('i-dF2-OoiiUi', [{ column: 'Action', value: 'Make the bed' }]);
+await table.updateRow("i-dF2-OoiiUi", [
+  { column: "Action", value: "Make the bed" },
+]);
 
 // updating off of an already fetched row
 await row2.update({
-  'ai-dRD9afcc8': 'To the moon, Alice!',
+  "ai-dRD9afcc8": "To the moon, Alice!",
 });
 ```
 
@@ -154,14 +160,14 @@ await row2.update({
 
 ```js
 // delete row directly
-const row4 = await table.getRow('i-Ef2-OoZxIi');
+const row4 = await table.getRow("i-Ef2-OoZxIi");
 await row4.delete();
 
 // delete row from table
-await table.deleteRow('i-cpDDoshUEU');
+await table.deleteRow("i-cpDDoshUEU");
 
 // deleting multiple rows from table
-await table.deleteRows(['i-cpDDoshUEU', 'i-jj81vtosO1']);
+await table.deleteRows(["i-cpDDoshUEU", "i-jj81vtosO1"]);
 ```
 
 #### Error Handling
@@ -176,7 +182,7 @@ Error types:
 - TooManyRequestsError (429)
 
 ```js
-import { Coda, UnauthorizedError, NotFoundError } from '../index';
+import { Coda, UnauthorizedError, NotFoundError } from "../index";
 const coda = new Coda(process.env.TOKEN);
 
 // doesn't have access to view docs
@@ -189,7 +195,7 @@ try {
 
 // fails to find a doc with a bad ID
 try {
-  const BAD_DOC_ID = 'd-ckjd1013kkk';
+  const BAD_DOC_ID = "d-ckjd1013kkk";
   await coda.listTables(BAD_DOC_ID);
 } catch (error) {
   // error is instance of NotFoundError

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ const firstRow = rows[0];
 console.log(firstRow.values); // column/value pairs
 console.log(firstRow.listValues()); // each column is object with column and value properties
 
-const tabeType =table.tableType; //get tableType
+const tableType =table.tableType; //get tableType
 const parentTable = tableType==="view" ? return table.parentTable : table; // if the table is a view, we can access its parent Table.
 console.log(parentTable.id)
 

--- a/src/API.ts
+++ b/src/API.ts
@@ -1,12 +1,12 @@
-import axios, { AxiosRequestConfig, AxiosError, Method } from "axios";
-import * as Errors from "./errors";
+import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
+import * as Errors from './errors';
 
 class API {
   private _axiosInstance: any;
 
   constructor(token: string) {
     this._axiosInstance = axios.create({
-      baseURL: "https://coda.io/apis/v1",
+      baseURL: 'https://coda.io/apis/v1',
       headers: { Authorization: `Bearer ${token}` },
     });
   }
@@ -14,9 +14,9 @@ class API {
   async request(
     url: string,
     params: any = {},
-    method: Method = "GET"
+    method: Method = 'GET'
   ): Promise<any> {
-    const options: AxiosRequestConfig = ["POST", "PUT", "PATCH"].includes(
+    const options: AxiosRequestConfig = ['POST', 'PUT', 'PATCH'].includes(
       method.toUpperCase()
     )
       ? { url, method, data: params }
@@ -25,7 +25,7 @@ class API {
   }
 
   async deleteWithBody(url: string, params: any = {}): Promise<any> {
-    const options: AxiosRequestConfig = { url, method: "DELETE", data: params };
+    const options: AxiosRequestConfig = { url, method: 'DELETE', data: params };
     return await this._axiosInstance(options).catch(determineErrorType);
   }
 }

--- a/src/API.ts
+++ b/src/API.ts
@@ -1,23 +1,31 @@
-import axios, { AxiosRequestConfig, AxiosError, Method } from 'axios';
-import * as Errors from './errors';
+import axios, { AxiosRequestConfig, AxiosError, Method } from "axios";
+import * as Errors from "./errors";
 
 class API {
   private _axiosInstance: any;
 
   constructor(token: string) {
     this._axiosInstance = axios.create({
-      baseURL: 'https://coda.io/apis/v1beta1',
+      baseURL: "https://coda.io/apis/v1",
       headers: { Authorization: `Bearer ${token}` },
     });
   }
 
-  async request(url: string, params: any = {}, method: Method = 'GET'): Promise<any> {
-    const options: AxiosRequestConfig = ['POST', 'PUT', 'PATCH'].includes(method.toUpperCase()) ? { url, method, data: params } : { url, method, params };
+  async request(
+    url: string,
+    params: any = {},
+    method: Method = "GET"
+  ): Promise<any> {
+    const options: AxiosRequestConfig = ["POST", "PUT", "PATCH"].includes(
+      method.toUpperCase()
+    )
+      ? { url, method, data: params }
+      : { url, method, params };
     return await this._axiosInstance(options).catch(determineErrorType);
   }
 
   async deleteWithBody(url: string, params: any = {}): Promise<any> {
-    const options: AxiosRequestConfig = { url, method: 'DELETE', data: params };
+    const options: AxiosRequestConfig = { url, method: "DELETE", data: params };
     return await this._axiosInstance(options).catch(determineErrorType);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export class Coda {
   /**
    * Returns an array of docs.
    *
-   * @param array $params Optional query parameters listed here https://coda.io/developers/apis/v1beta1#operation/listDocs
+   * @param array $params Optional query parameters listed here https://coda.io/developers/apis/v1#operation/listDocs
    * @return array
    */
   async listDocs(params: any = {}): Promise<Doc[]> {
@@ -38,27 +38,27 @@ export class Coda {
 
   async listPages(docId: string, params: any): Promise<Page[]> {
     // params: limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listPages
+    // https://coda.io/developers/apis/v1#operation/listPages
     const { data } = await this.API.request(`/docs/${docId}/Pages`, params);
     return data.items.map((Page) => new Page({ ...Page, docId })); // map all items into Pages
   }
 
-  async getPage(docId: string, PageIdOrName: string): Promise<Page> {
-    // https://coda.io/developers/apis/v1beta1#operation/getPage
+  async getPage(docId: string, pageIdOrName: string): Promise<Page> {
+    // https://coda.io/developers/apis/v1#operation/getPage
     const { data } = await this.API.request(
-      `/docs/${docId}/Pages/${PageIdOrName}`
+      `/docs/${docId}/Pages/${pageIdOrName}`
     );
     return new Page({ ...data, docId });
   }
 
   async listTables(docId: string): Promise<Table[]> {
-    // https://coda.io/developers/apis/v1beta1#operation/listTables
+    // https://coda.io/developers/apis/v1#operation/listTables
     const { data } = await this.API.request(`/docs/${docId}/tables`);
     return data.items.map((table) => new Table(this.API, { ...table, docId })); // map all items into tables
   }
 
   async getTable(docId: string, tableIdOrName: string): Promise<Table> {
-    // https://coda.io/developers/apis/v1beta1#operation/getTable
+    // https://coda.io/developers/apis/v1#operation/getTable
     const { data } = await this.API.request(
       `/docs/${docId}/tables/${tableIdOrName}`
     );
@@ -71,7 +71,7 @@ export class Coda {
     params: any
   ): Promise<Column[]> {
     // params: limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listColumns
+    // https://coda.io/developers/apis/v1#operation/listColumns
     const { data } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/columns`,
       params
@@ -86,7 +86,7 @@ export class Coda {
     tableId: string,
     columnIdOrName: string
   ): Promise<Column> {
-    // https://coda.io/developers/apis/v1beta1#operation/getColumn
+    // https://coda.io/developers/apis/v1#operation/getColumn
     const { data } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/columns/${columnIdOrName}`
     );
@@ -95,7 +95,7 @@ export class Coda {
 
   async listRows(docId: string, tableId: string, params: any): Promise<Row[]> {
     // params: query, useColumnNames, limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listRows
+    // https://coda.io/developers/apis/v1#operation/listRows
     const { data } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows`,
       params
@@ -112,7 +112,7 @@ export class Coda {
     params: any
   ): Promise<Row> {
     // params: useColumnNames
-    // https://coda.io/developers/apis/v1beta1#operation/getColumn
+    // https://coda.io/developers/apis/v1#operation/getColumn
     const { data } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
       params
@@ -128,7 +128,7 @@ export class Coda {
     keyColumns: any[] = []
   ): Promise<boolean> {
     // params: rows (array - required), keyColumns (array)
-    // https://coda.io/developers/apis/v1beta1#operation/upsertRows
+    // https://coda.io/developers/apis/v1#operation/upsertRows
 
     const formattedRows = formatRows(rows);
     const params = { rows: formattedRows, keyColumns };
@@ -148,7 +148,7 @@ export class Coda {
     row: any
   ): Promise<boolean> {
     // params: row (array - required)
-    // https://coda.io/developers/apis/v1beta1#operation/updateRow
+    // https://coda.io/developers/apis/v1#operation/updateRow
 
     const [formattedRow] = formatRows([row]);
     const params = { row: formattedRow };
@@ -166,7 +166,7 @@ export class Coda {
     tableId: string,
     rowIdOrName: string
   ): Promise<boolean> {
-    // https://coda.io/developers/apis/v1beta1#operation/deleteRow
+    // https://coda.io/developers/apis/v1#operation/deleteRow
 
     const { status } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
@@ -181,7 +181,7 @@ export class Coda {
     tableId: string,
     rowIds: string[]
   ): Promise<boolean> {
-    // https://coda.io/developers/apis/v1beta1#operation/deleteRows
+    // https://coda.io/developers/apis/v1#operation/deleteRows
 
     const params = { rowIds };
     const { status } = await this.API.deleteWithBody(
@@ -193,13 +193,13 @@ export class Coda {
 
   async listControls(docId: string, params: any): Promise<Page[]> {
     // params: limit, pageToken, sortBy
-    // https://coda.io/developers/apis/v1beta1#operation/listControls
+    // https://coda.io/developers/apis/v1#operation/listControls
     const { data } = await this.API.request(`/docs/${docId}/controls`, params);
     return data.items.map((control) => new Control({ ...control, docId })); // map all items into Pages
   }
 
   async getControl(docId: string, controlIdOrName: string): Promise<Page> {
-    // https://coda.io/developers/apis/v1beta1#operation/getControl
+    // https://coda.io/developers/apis/v1#operation/getControl
     const { data } = await this.API.request(
       `/docs/${docId}/controls/${controlIdOrName}`
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import API from "./API";
-import { Doc, Table, Row, Column, Page, Control } from "./models/index";
-import { formatRows } from "./models/utilities";
-export * from "./errors";
+import API from './API';
+import { Doc, Table, Row, Column, Page, Control } from './models/index';
+import { formatRows } from './models/utilities';
+export * from './errors';
 
 export class Coda {
   API: API;
@@ -16,7 +16,7 @@ export class Coda {
    * @return object
    */
   async whoAmI(): Promise<any> {
-    const { data } = await this.API.request("/whoami");
+    const { data } = await this.API.request('/whoami');
     return data;
   }
 
@@ -27,7 +27,7 @@ export class Coda {
    * @return array
    */
   async listDocs(params: any = {}): Promise<Doc[]> {
-    const { data } = await this.API.request("/docs", params);
+    const { data } = await this.API.request('/docs', params);
     return data.items.map((doc) => new Doc(this.API, doc)); // map all items into docs
   }
 
@@ -136,7 +136,7 @@ export class Coda {
     const { status } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows`,
       params,
-      "POST"
+      'POST'
     );
     return status === 202;
   }
@@ -156,7 +156,7 @@ export class Coda {
     const { status } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
       params,
-      "PUT"
+      'PUT'
     );
     return status === 202;
   }
@@ -171,7 +171,7 @@ export class Coda {
     const { status } = await this.API.request(
       `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
       {},
-      "DELETE"
+      'DELETE'
     );
     return status === 202;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import API from './API';
-import { Doc, Table, Row, Column, Section, Folder, Control } from './models/index';
-import { formatRows } from './models/utilities';
-export * from './errors';
+import API from "./API";
+import { Doc, Table, Row, Column, Page, Control } from "./models/index";
+import { formatRows } from "./models/utilities";
+export * from "./errors";
 
 export class Coda {
   API: API;
@@ -16,7 +16,7 @@ export class Coda {
    * @return object
    */
   async whoAmI(): Promise<any> {
-    const { data } = await this.API.request('/whoami');
+    const { data } = await this.API.request("/whoami");
     return data;
   }
 
@@ -27,7 +27,7 @@ export class Coda {
    * @return array
    */
   async listDocs(params: any = {}): Promise<Doc[]> {
-    const { data } = await this.API.request('/docs', params);
+    const { data } = await this.API.request("/docs", params);
     return data.items.map((doc) => new Doc(this.API, doc)); // map all items into docs
   }
 
@@ -36,30 +36,19 @@ export class Coda {
     return new Doc(this.API, data);
   }
 
-  async listSections(docId: string, params: any): Promise<Section[]> {
+  async listPages(docId: string, params: any): Promise<Page[]> {
     // params: limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listSections
-    const { data } = await this.API.request(`/docs/${docId}/sections`, params);
-    return data.items.map((section) => new Section({ ...section, docId })); // map all items into sections
+    // https://coda.io/developers/apis/v1beta1#operation/listPages
+    const { data } = await this.API.request(`/docs/${docId}/Pages`, params);
+    return data.items.map((Page) => new Page({ ...Page, docId })); // map all items into Pages
   }
 
-  async getSection(docId: string, sectionIdOrName: string): Promise<Section> {
-    // https://coda.io/developers/apis/v1beta1#operation/getSection
-    const { data } = await this.API.request(`/docs/${docId}/sections/${sectionIdOrName}`);
-    return new Section({ ...data, docId });
-  }
-
-  async listFolders(docId: string, params: any): Promise<Folder[]> {
-    // params: limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listFolders
-    const { data } = await this.API.request(`/docs/${docId}/folders`, params);
-    return data.items.map((folder) => new Folder({ ...folder, docId })); // map all items into folders
-  }
-
-  async getFolder(docId: string, folderIdOrName: string): Promise<Folder> {
-    // https://coda.io/developers/apis/v1beta1#operation/getFolder
-    const { data } = await this.API.request(`/docs/${docId}/folders/${folderIdOrName}`);
-    return new Folder({ ...data, docId });
+  async getPage(docId: string, PageIdOrName: string): Promise<Page> {
+    // https://coda.io/developers/apis/v1beta1#operation/getPage
+    const { data } = await this.API.request(
+      `/docs/${docId}/Pages/${PageIdOrName}`
+    );
+    return new Page({ ...data, docId });
   }
 
   async listTables(docId: string): Promise<Table[]> {
@@ -70,85 +59,150 @@ export class Coda {
 
   async getTable(docId: string, tableIdOrName: string): Promise<Table> {
     // https://coda.io/developers/apis/v1beta1#operation/getTable
-    const { data } = await this.API.request(`/docs/${docId}/tables/${tableIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${docId}/tables/${tableIdOrName}`
+    );
     return new Table(this.API, { ...data, docId });
   }
 
-  async listColumns(docId: string, tableId: string, params: any): Promise<Column[]> {
+  async listColumns(
+    docId: string,
+    tableId: string,
+    params: any
+  ): Promise<Column[]> {
     // params: limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listColumns
-    const { data } = await this.API.request(`/docs/${docId}/tables/${tableId}/columns`, params);
-    return data.items.map((column) => new Column({ ...column, docId, tableId })); // map all items into Columns
+    const { data } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/columns`,
+      params
+    );
+    return data.items.map(
+      (column) => new Column({ ...column, docId, tableId })
+    ); // map all items into Columns
   }
 
-  async getColumn(docId: string, tableId: string, columnIdOrName: string): Promise<Column> {
+  async getColumn(
+    docId: string,
+    tableId: string,
+    columnIdOrName: string
+  ): Promise<Column> {
     // https://coda.io/developers/apis/v1beta1#operation/getColumn
-    const { data } = await this.API.request(`/docs/${docId}/tables/${tableId}/columns/${columnIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/columns/${columnIdOrName}`
+    );
     return new Column({ ...data, docId, tableId });
   }
 
   async listRows(docId: string, tableId: string, params: any): Promise<Row[]> {
     // params: query, useColumnNames, limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listRows
-    const { data } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows`, params);
-    return data.items.map((row) => new Row(this.API, { ...row, docId, tableId })); // map all items into Rows
+    const { data } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/rows`,
+      params
+    );
+    return data.items.map(
+      (row) => new Row(this.API, { ...row, docId, tableId })
+    ); // map all items into Rows
   }
 
-  async getRow(docId: string, tableId: string, rowIdOrName: string, params: any): Promise<Row> {
+  async getRow(
+    docId: string,
+    tableId: string,
+    rowIdOrName: string,
+    params: any
+  ): Promise<Row> {
     // params: useColumnNames
     // https://coda.io/developers/apis/v1beta1#operation/getColumn
-    const { data } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`, params);
+    const { data } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
+      params
+    );
     return new Row(this.API, { ...data, docId, tableId });
   }
 
   // upserts rows
-  async insertRows(docId: string, tableId: string, rows: any[] = [], keyColumns: any[] = []): Promise<boolean> {
+  async insertRows(
+    docId: string,
+    tableId: string,
+    rows: any[] = [],
+    keyColumns: any[] = []
+  ): Promise<boolean> {
     // params: rows (array - required), keyColumns (array)
     // https://coda.io/developers/apis/v1beta1#operation/upsertRows
 
     const formattedRows = formatRows(rows);
     const params = { rows: formattedRows, keyColumns };
 
-    const { status } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows`, params, 'POST');
+    const { status } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/rows`,
+      params,
+      "POST"
+    );
     return status === 202;
   }
 
-  async updateRow(docId: string, tableId: string, rowIdOrName: string, row: any): Promise<boolean> {
+  async updateRow(
+    docId: string,
+    tableId: string,
+    rowIdOrName: string,
+    row: any
+  ): Promise<boolean> {
     // params: row (array - required)
     // https://coda.io/developers/apis/v1beta1#operation/updateRow
 
     const [formattedRow] = formatRows([row]);
     const params = { row: formattedRow };
 
-    const { status } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`, params, 'PUT');
+    const { status } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
+      params,
+      "PUT"
+    );
     return status === 202;
   }
 
-  async deleteRow(docId: string, tableId: string, rowIdOrName: string): Promise<boolean> {
+  async deleteRow(
+    docId: string,
+    tableId: string,
+    rowIdOrName: string
+  ): Promise<boolean> {
     // https://coda.io/developers/apis/v1beta1#operation/deleteRow
 
-    const { status } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`, {}, 'DELETE');
+    const { status } = await this.API.request(
+      `/docs/${docId}/tables/${tableId}/rows/${rowIdOrName}`,
+      {},
+      "DELETE"
+    );
     return status === 202;
   }
 
-  async deleteRows(docId: string, tableId: string, rowIds: string[]): Promise<boolean> {
+  async deleteRows(
+    docId: string,
+    tableId: string,
+    rowIds: string[]
+  ): Promise<boolean> {
     // https://coda.io/developers/apis/v1beta1#operation/deleteRows
 
     const params = { rowIds };
-    const { status } = await this.API.deleteWithBody(`/docs/${docId}/tables/${tableId}/rows`, params);
+    const { status } = await this.API.deleteWithBody(
+      `/docs/${docId}/tables/${tableId}/rows`,
+      params
+    );
     return status === 202;
   }
 
-  async listControls(docId: string, params: any): Promise<Section[]> {
+  async listControls(docId: string, params: any): Promise<Page[]> {
     // params: limit, pageToken, sortBy
     // https://coda.io/developers/apis/v1beta1#operation/listControls
     const { data } = await this.API.request(`/docs/${docId}/controls`, params);
-    return data.items.map((control) => new Control({ ...control, docId })); // map all items into sections
+    return data.items.map((control) => new Control({ ...control, docId })); // map all items into Pages
   }
 
-  async getControl(docId: string, controlIdOrName: string): Promise<Section> {
+  async getControl(docId: string, controlIdOrName: string): Promise<Page> {
     // https://coda.io/developers/apis/v1beta1#operation/getControl
-    const { data } = await this.API.request(`/docs/${docId}/controls/${controlIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${docId}/controls/${controlIdOrName}`
+    );
     return new Control({ ...data, docId });
   }
 }

--- a/src/models/Doc.ts
+++ b/src/models/Doc.ts
@@ -1,8 +1,7 @@
-import Table from "./Table";
-import Section from "./Page";
-import Folder from "./Folder";
-import Control from "./Control";
-import API from "../API";
+import Table from './Table';
+import Section from './Page';
+import Control from './Control';
+import API from '../API';
 
 class Doc {
   API: API;
@@ -32,23 +31,6 @@ class Doc {
       `/docs/${this.id}/sections/${sectionIdOrName}`
     );
     return new Section({ ...data, docId: this.id });
-  }
-
-  async listFolders(params: any): Promise<Folder[]> {
-    // params: limit, pageToken
-    // https://coda.io/developers/apis/v1beta1#operation/listFolders
-    const { data } = await this.API.request(`/docs/${this.id}/folders`, params);
-    return data.items.map(
-      (folder) => new Folder({ ...folder, docId: this.id })
-    ); // map all items into folders
-  }
-
-  async getFolder(folderIdOrName: string): Promise<Folder> {
-    // https://coda.io/developers/apis/v1beta1#operation/getFolder
-    const { data } = await this.API.request(
-      `/docs/${this.id}/folders/${folderIdOrName}`
-    );
-    return new Folder({ ...data, docId: this.id });
   }
 
   async listTables(): Promise<Table[]> {

--- a/src/models/Doc.ts
+++ b/src/models/Doc.ts
@@ -1,8 +1,8 @@
-import Table from './Table';
-import Section from './Section';
-import Folder from './Folder';
-import Control from './Control';
-import API from '../API';
+import Table from "./Table";
+import Section from "./Page";
+import Folder from "./Folder";
+import Control from "./Control";
+import API from "../API";
 
 class Doc {
   API: API;
@@ -17,13 +17,20 @@ class Doc {
   async listSections(params: any): Promise<Section[]> {
     // params: limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listSections
-    const { data } = await this.API.request(`/docs/${this.id}/sections`, params);
-    return data.items.map((section) => new Section({ ...section, docId: this.id })); // map all items into sections
+    const { data } = await this.API.request(
+      `/docs/${this.id}/sections`,
+      params
+    );
+    return data.items.map(
+      (section) => new Section({ ...section, docId: this.id })
+    ); // map all items into sections
   }
 
   async getSection(sectionIdOrName: string): Promise<Section> {
     // https://coda.io/developers/apis/v1beta1#operation/getSection
-    const { data } = await this.API.request(`/docs/${this.id}/sections/${sectionIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${this.id}/sections/${sectionIdOrName}`
+    );
     return new Section({ ...data, docId: this.id });
   }
 
@@ -31,36 +38,51 @@ class Doc {
     // params: limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listFolders
     const { data } = await this.API.request(`/docs/${this.id}/folders`, params);
-    return data.items.map((folder) => new Folder({ ...folder, docId: this.id })); // map all items into folders
+    return data.items.map(
+      (folder) => new Folder({ ...folder, docId: this.id })
+    ); // map all items into folders
   }
 
   async getFolder(folderIdOrName: string): Promise<Folder> {
     // https://coda.io/developers/apis/v1beta1#operation/getFolder
-    const { data } = await this.API.request(`/docs/${this.id}/folders/${folderIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${this.id}/folders/${folderIdOrName}`
+    );
     return new Folder({ ...data, docId: this.id });
   }
 
   async listTables(): Promise<Table[]> {
     // https://coda.io/developers/apis/v1beta1#operation/listTables
     const { data } = await this.API.request(`/docs/${this.id}/tables`);
-    return data.items.map((table) => new Table(this.API, { ...table, docId: this.id })); // map all items into tables
+    return data.items.map(
+      (table) => new Table(this.API, { ...table, docId: this.id })
+    ); // map all items into tables
   }
 
   async getTable(tableIdOrName: string): Promise<Table> {
     // https://coda.io/developers/apis/v1beta1#operation/getTable
-    const { data } = await this.API.request(`/docs/${this.id}/tables/${tableIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${this.id}/tables/${tableIdOrName}`
+    );
     return new Table(this.API, { ...data, docId: this.id });
   }
 
   async listControls(params: any): Promise<Control[]> {
     // https://coda.io/developers/apis/v1beta1#operation/listControls
-    const { data } = await this.API.request(`/docs/${this.id}/controls`, params);
-    return data.items.map((control) => new Control({ ...control, docId: this.id })); // map all items into controls
+    const { data } = await this.API.request(
+      `/docs/${this.id}/controls`,
+      params
+    );
+    return data.items.map(
+      (control) => new Control({ ...control, docId: this.id })
+    ); // map all items into controls
   }
 
   async getControl(controlIdOrName: string): Promise<Control> {
     // https://coda.io/developers/apis/v1beta1#operation/getControl
-    const { data } = await this.API.request(`/docs/${this.id}/controls/${controlIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${this.id}/controls/${controlIdOrName}`
+    );
     return new Control({ ...data, docId: this.id });
   }
 }

--- a/src/models/Folder.ts
+++ b/src/models/Folder.ts
@@ -1,8 +1,0 @@
-class Folder {
-  constructor(data: any) {
-    // set properties (docId, id, type, href, name, children)
-    Object.assign(this, data);
-  }
-}
-
-export default Folder;

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -1,8 +1,8 @@
-class Section {
+class Page {
   constructor(data: any) {
     // set properties (docId, id, type, href, name, browserLink)
     Object.assign(this, data);
   }
 }
 
-export default Section;
+export default Page;

--- a/src/models/Table.ts
+++ b/src/models/Table.ts
@@ -1,7 +1,7 @@
-import Column from './Column';
-import Row from './Row';
-import { formatRows } from './utilities';
-import API from '../API';
+import Column from "./Column";
+import Row from "./Row";
+import { formatRows } from "./utilities";
+import API from "../API";
 
 class Table {
   API: API;
@@ -10,42 +10,66 @@ class Table {
 
   constructor(API: API, data: any) {
     this.API = API;
-    // set properties (docId, id, type, href, browserLink, name, displayColumn (object), rowCount, createdAt, updatedAt, sorts, layout)
+    // set properties (docId, id, type, href, browserLink, name, parent(object),parentTable(object),displayColumn (object), rowCount, createdAt, updatedAt, sorts, layout)
     Object.assign(this, data);
   }
 
   async listColumns(params: any): Promise<Column[]> {
     // params: limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listColumns
-    const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/columns`, params);
-    return data.items.map(column => new Column({ ...column, docId: this.docId, tableId: this.id })); // map all items into Columns
+    const { data } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/columns`,
+      params
+    );
+    return data.items.map(
+      (column) => new Column({ ...column, docId: this.docId, tableId: this.id })
+    ); // map all items into Columns
   }
 
   async getColumn(columnIdOrName: string): Promise<Column> {
     // https://coda.io/developers/apis/v1beta1#operation/getColumn
-    const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/columns/${columnIdOrName}`);
+    const { data } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/columns/${columnIdOrName}`
+    );
     return new Column({ ...data, docId: this.docId, tableId: this.id });
   }
 
   async listRows(params: any): Promise<Row[]> {
     // params: query, useColumnNames, limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listRows
-    const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows`, params);
-    return data.items.map(row => new Row(this.API, { ...row, docId: this.docId, tableId: this.id })); // map all items into Rows
+    const { data } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows`,
+      params
+    );
+    return data.items.map(
+      (row) =>
+        new Row(this.API, { ...row, docId: this.docId, tableId: this.id })
+    ); // map all items into Rows
   }
 
-  async listRowsPaginatedByToken(params: any): Promise<{ items: Row[]; token: string }> {
+  async listRowsPaginatedByToken(
+    params: any
+  ): Promise<{ items: Row[]; token: string }> {
     // params: query, useColumnNames, limit, pageToken
     // https://coda.io/developers/apis/v1beta1#operation/listRows
-    const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows`, params);
-    const items = data.items.map(row => new Row(this.API, { ...row, docId: this.docId, tableId: this.id })); // map all items into Rows
+    const { data } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows`,
+      params
+    );
+    const items = data.items.map(
+      (row) =>
+        new Row(this.API, { ...row, docId: this.docId, tableId: this.id })
+    ); // map all items into Rows
     return { items, token: data.nextPageToken as string };
   }
 
   async getRow(rowIdOrName: string, params: any): Promise<Row> {
     // params: useColumnNames
     // https://coda.io/developers/apis/v1beta1#operation/getColumn
-    const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`, params);
+    const { data } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`,
+      params
+    );
     return new Row(this.API, { ...data, docId: this.docId, tableId: this.id });
   }
 
@@ -57,7 +81,11 @@ class Table {
     const formattedRows = formatRows(rows);
     const params = { rows: formattedRows, keyColumns };
 
-    const { status } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows`, params, 'POST');
+    const { status } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows`,
+      params,
+      "POST"
+    );
     return status === 202;
   }
 
@@ -68,14 +96,22 @@ class Table {
     const [formattedRow] = formatRows([row]);
     const params = { row: formattedRow };
 
-    const { status } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`, params, 'PUT');
+    const { status } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`,
+      params,
+      "PUT"
+    );
     return status === 202;
   }
 
   async deleteRow(rowIdOrName: string): Promise<boolean> {
     // https://coda.io/developers/apis/v1beta1#operation/deleteRow
 
-    const { status } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`, {}, 'DELETE');
+    const { status } = await this.API.request(
+      `/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`,
+      {},
+      "DELETE"
+    );
     return status === 202;
   }
 
@@ -83,7 +119,10 @@ class Table {
     // https://coda.io/developers/apis/v1beta1#operation/deleteRows
 
     const params = { rowIds };
-    const { status } = await this.API.deleteWithBody(`/docs/${this.docId}/tables/${this.id}/rows`, params);
+    const { status } = await this.API.deleteWithBody(
+      `/docs/${this.docId}/tables/${this.id}/rows`,
+      params
+    );
     return status === 202;
   }
 }

--- a/src/models/Table.ts
+++ b/src/models/Table.ts
@@ -1,7 +1,7 @@
-import Column from "./Column";
-import Row from "./Row";
-import { formatRows } from "./utilities";
-import API from "../API";
+import Column from './Column';
+import Row from './Row';
+import { formatRows } from './utilities';
+import API from '../API';
 
 class Table {
   API: API;
@@ -84,7 +84,7 @@ class Table {
     const { status } = await this.API.request(
       `/docs/${this.docId}/tables/${this.id}/rows`,
       params,
-      "POST"
+      'POST'
     );
     return status === 202;
   }
@@ -99,7 +99,7 @@ class Table {
     const { status } = await this.API.request(
       `/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`,
       params,
-      "PUT"
+      'PUT'
     );
     return status === 202;
   }
@@ -110,7 +110,7 @@ class Table {
     const { status } = await this.API.request(
       `/docs/${this.docId}/tables/${this.id}/rows/${rowIdOrName}`,
       {},
-      "DELETE"
+      'DELETE'
     );
     return status === 202;
   }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,9 +1,9 @@
-import Doc from './Doc';
-import Table from './Table';
-import Row from './Row';
-import Column from './Column';
-import Section from './Section';
-import Folder from './Folder';
-import Control from './Control';
+import Doc from "./Doc";
+import Table from "./Table";
+import Row from "./Row";
+import Column from "./Column";
+import Page from "./Page";
 
-export { Doc, Table, Row, Column, Section, Folder, Control };
+import Control from "./Control";
+
+export { Doc, Table, Row, Column, Page, Control };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,9 +1,9 @@
-import Doc from "./Doc";
-import Table from "./Table";
-import Row from "./Row";
-import Column from "./Column";
-import Page from "./Page";
+import Doc from './Doc';
+import Table from './Table';
+import Row from './Row';
+import Column from './Column';
+import Page from './Page';
 
-import Control from "./Control";
+import Control from './Control';
 
 export { Doc, Table, Row, Column, Page, Control };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,7 +3,6 @@ import Table from './Table';
 import Row from './Row';
 import Column from './Column';
 import Page from './Page';
-
 import Control from './Control';
 
 export { Doc, Table, Row, Column, Page, Control };


### PR DESCRIPTION
> 1. update request path to use v1 in` API.ts`
> 2. we didn't have a views API before so users can just use the table API 😂
>     - note the new tableType property in `models/Table.ts` comment
>     -  add something to README examples that shows tableType can be access to tell if it's a table or view
> 3. remove all references to Folders API
> 4. convert all references of Sections to Pages (eg. getPage(...) instead of getSection(...))