### PR TITLE
Add the addedRowIds property to PendingRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ const controls = await firstDoc.listControls();
 
 #### Inserting
 
-Inserting also has a second parameter of keyColumns that allows for an "upsert". See Coda documentation for details.
+Inserting also has an optional second parameter of keyColumns that allows for an "upsert". If keyColumns is not specified, or the passed array is empty, the call returns an addedRowIds value which is an array of strings specifying the ID for each inserted row. See Coda documentation for details.
 
 ```js
 // inserting using object

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class Coda {
     const params = { rows: formattedRows, keyColumns };
 
     const { data } = await this.API.request(`/docs/${docId}/tables/${tableId}/rows`, params, 'POST');
-    return new PendingRequest(this.API, data.requestId);
+    return new PendingRequest(this.API, data.requestId, data.addedRowIds);
   }
 
   // params: row (array - required)

--- a/src/models/PendingRequest.ts
+++ b/src/models/PendingRequest.ts
@@ -3,10 +3,12 @@ import API from '../API';
 class PendingRequest {
   API: API;
   requestId: string;
+  addedRowIds?: string[]
 
-  constructor(API: API, requestId: string) {
+  constructor(API: API, requestId: string, addedRowIds?: string[]) {
     this.API = API;
     this.requestId = requestId;
+    if (addedRowIds) this.addedRowIds = addedRowIds;
   }
 
   // check to see if request that generated this pending request is completed

--- a/src/models/Table.ts
+++ b/src/models/Table.ts
@@ -58,7 +58,7 @@ class Table {
     const params = { rows: formattedRows, keyColumns };
 
     const { data } = await this.API.request(`/docs/${this.docId}/tables/${this.id}/rows`, params, 'POST');
-    return new PendingRequest(this.API, data.requestId);
+    return new PendingRequest(this.API, data.requestId, data.addedRowIds);
   }
 
   // params: row (array - required)


### PR DESCRIPTION
This PR adds an `addedRowIds` property to the `PendingRequest` class as described in the [Coda API 1.4.17 documentation](https://coda.io/developers/apis/v1#tag/Rows/operation/upsertRows). 

This PR is intended to address issue https://github.com/parker-codes/coda-js/issues/29.