### PR TITLE
Add name field to Table class

### DIFF
--- a/src/models/Table.ts
+++ b/src/models/Table.ts
@@ -8,6 +8,7 @@ class Table {
   API: API;
   id?: string;
   docId?: string;
+  name?: string;
 
   constructor(API: API, data: any) {
     this.API = API;


### PR DESCRIPTION
Currently using `name` field on `Table` object results in typescript error: `Property 'name' does not exist on type 'Table'.`
This PR fixes it